### PR TITLE
For multimodule plugin added valid path for 2.x ca-apm-plugin

### DIFF
--- a/permissions/plugin-ca-apm.yml
+++ b/permissions/plugin-ca-apm.yml
@@ -3,6 +3,7 @@ name: "ca-apm"
 github: "jenkinsci/ca-apm-plugin"
 paths:
 - "org/jenkins-ci/plugins/ca-apm"
+- "org/jenkins-ci/plugins/ca-apm-plugin"
 #added new developer
 developers:
 - "srikns"


### PR DESCRIPTION
Access denied to: https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/ca-apm-plugin/2.0-alpha-2/ca-apm-plugin-2.0-alpha-2.pom, ReasonPhrase: Forbidden.

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
Repository is - https://github.com/jenkinsci/ca-apm-plugin
commiter - Me and @srikns 

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
